### PR TITLE
save to table button and table added in PI

### DIFF
--- a/vin_isipl/hooks.py
+++ b/vin_isipl/hooks.py
@@ -246,6 +246,13 @@ before_uninstall = "vin_isipl.uninstall.before_uninstall"
 # }
 
 doctype_js = {
-    "Item" : "public/js/item.js"
+    "Item" : "public/js/item.js",
+    "Quotation" : "public/js/proforma_invoice.js"
     }
+
+fixtures = [
+    {"dt": "Insights Workbook"}
+]
+
+
 

--- a/vin_isipl/public/js/proforma_invoice.js
+++ b/vin_isipl/public/js/proforma_invoice.js
@@ -1,0 +1,18 @@
+frappe.ui.form.on('Quotation', {
+    refresh: function (frm) {
+        if (!frm.is_new()) {           
+            frm.add_custom_button('Save to Table', function () {
+                frappe.call({
+                    method: "vin_isipl.utils.pi_version_tracker.save_to_table",
+                    args: {
+                        quotation_name: frm.doc.name
+                    },
+                    callback: function () {
+                        frappe.show_alert({ message: __("Version Tracker Updated!"), indicator: 'green' });
+
+                    }
+                });
+            });
+        }
+    }
+});

--- a/vin_isipl/utils/pi_version_tracker.py
+++ b/vin_isipl/utils/pi_version_tracker.py
@@ -1,0 +1,33 @@
+import frappe
+from frappe.utils.pdf import get_pdf
+from frappe.utils import now
+
+@frappe.whitelist()
+def save_to_table(quotation_name):
+    quotation = frappe.get_doc('Quotation', quotation_name)
+    
+    print_format = ""
+    if quotation.order_type == "STKPI":
+        print_format = "Machine PI"
+    elif quotation.order_type == "IMPPI":
+        print_format = "Import PI"
+    elif quotation.order_type == "SPPI":
+        print_format = "Spares PI"
+    elif quotation.order_type == "SRPI":
+        print_format = "Service PI"
+    pdf_data = get_pdf(frappe.get_print('Quotation', quotation_name, print_format))
+
+    file_doc = frappe.get_doc({
+        'doctype': 'File',
+        'file_name': f"{quotation_name}.pdf",
+        'content': pdf_data,
+        'is_private': 1
+    }).insert(ignore_permissions=True)
+
+    quotation.append('custom_pi_version_tracker', {
+        'created_by': frappe.session.user,
+        'created_on': now(),
+        'pdf_attachment': file_doc.file_url
+    })
+
+    quotation.save(ignore_permissions=True)


### PR DESCRIPTION
![Screenshot from 2025-03-27 19-46-21](https://github.com/user-attachments/assets/2deaaed6-73a9-4467-9cbc-f16c5edb2a80)


Created "Save to Table" button.
Created a child table to save the created on , created by and pdf attachement.
The pdf is rendered based on the print format mapping with order type.
On click the button populates the table.